### PR TITLE
added ipfs-boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ place to ask about it might be in [ipfs/apps](https://github.com/ipfs/apps) or
 * [ipfs-share](https://github.com/rameshvarun/ipfs-share) - Pastebin/Image host/File sharing application
 * [markup.rocks](https://github.com/davidar/markup.rocks) - Pandoc-based markup editor/previewer/converter, ported to IPFS. [Example](https://ipfs.io/ipfs/QmWPgJnUGLB1LPh9KMG9LEN4LVu5e17TwkEtcmTWdNn9V6/#/ipfs/QmfQ75DjAxYzxMP2hdm6o4wFwZS5t7uorEZ2pX9AKXEg2u)
 * [beets](https://github.com/sampsyo/beets) - Beets has a plugin which allows for easy sharing of music libraries using IPFS
+* [Boards](http://ipfs.ydns.eu/ipns/boards.ydns.eu/) - Distributed social platform that runs in the browser. [GitHub](https://github.com/fazo96/ipfs-boards)
 
 ## Tools
 


### PR DESCRIPTION
Hi! I've been working on a distributed social platform and data sharing web app for a few months now, and I'm nearing a first usable release. Technically it works already and there's a version that runs without go-ipfs installed, in any modern browser. But I don't consider it reliable yet.

I thought about adding it here so that I can get some more feedback about it. And also because I hope it's at least a little bit cool :+1: 

Check it out: [website](http://boards.ydns.eu) [repo](https://github.com/fazo96/ipfs-boards)