### PR TITLE
Update link to hasteIPFS to link global gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These are narrowly-scoped, little JS "apps" deployed through IPFS.
 - [a qr-code renderer](https://github.com/ipfs/examples/tree/master/webapps/qr-render) - [example](
   https://ipfs.io/ipfs/QmccqhJg5wm5kNjAP4k4HrYxoqaXUGNuotDUqfvYBx8jrR/qr#enter%20text%20here
 )
-- [hasteIPFS](http://bin.kubuxu.ovh) - IPFS based code bin. (Read only for now)
+- [hasteIPFS](https://ipfs.io/ipns/bin.kubuxu.ovh/) - IPFS based code bin. (Read only for now)
 
 ## Tools
 


### PR DESCRIPTION
This way I don't have to curate DNS entries for servers and if someone is using browser plug-in the transformation works.