### PR TITLE
Change URL of hasteIPFS to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These are narrowly-scoped, little JS "apps" deployed through IPFS.
 - [a qr-code renderer](https://github.com/ipfs/examples/tree/master/webapps/qr-render) - [example](
   https://ipfs.io/ipfs/QmccqhJg5wm5kNjAP4k4HrYxoqaXUGNuotDUqfvYBx8jrR/qr#enter%20text%20here
 )
-- [hasteIPFS](https://ipfs.io/ipns/bin.kubuxu.ovh/) - IPFS based code bin. (Read only for now)
+- [hasteIPFS](https://ipfs.io/ipns/bin.ipfs.ovh/) - IPFS based code bin. (Read only for now)
 
 ## Tools
 


### PR DESCRIPTION
Sorry for changing it again but that form is final.

I couldn't know that I would buy ipfs.ovh when I was PRing it last time.
