### PR TITLE
Correct twitter shorted link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These are narrowly-scoped, little JS "apps" deployed through IPFS.
 
 * [IPFS Alpha - Why we must redistribute the web](https://www.youtube.com/watch?v=skMTdSEaCtA) (YouTube)
 * [Juan Bennet at Stanford 2015](https://www.youtube.com/watch?v=HUVmypx9HGI) (YouTube)
-* [Juan Bennet at Fullstack Fest 2016](https://www.youtube.com/watch?v=jONZtXMu03w) (YouTube) ([IPFS Mirror](https://t.co/RvXSFakZ3M))
+* [Juan Bennet at Fullstack Fest 2016](https://www.youtube.com/watch?v=jONZtXMu03w) (YouTube) ([IPFS Mirror](https://ipfs.io/ipfs/QmX8LDhDSYdX3xG6cHFUybXLDSuvo9Lz6wF5NU3UVmJRnB))
 
 ## Archives
 


### PR DESCRIPTION
When I added this mirror, somehow a twitter shortlink was added instead of the one to the public gateway. So I corrected it