### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ place to ask about it might be in [ipfs/apps](https://github.com/ipfs/apps) or
 ## Apps
 
 * [beets](https://github.com/beetbox/beets) - Beets has a plugin which allows for easy sharing of music libraries using IPFS
-* [Boards](http://boards.tech/) - Distributed social platform that runs in the browser. [GitHub](https://github.com/fazo96/ipfs-boards)
+* [Boards](https://ipfs.io/ipns/boards.ydns.eu) - Distributed social platform that runs in the browser. [GitHub](https://github.com/fazo96/ipfs-boards)
 * [Cohort](https://github.com/zignig/cohort) - A golang app to preset a threejs interface and get all of its assets out of IPFS.
 * [git-ipfs-rehost](https://github.com/whyrusleeping/git-ipfs-rehost) - A script to rehost your git repos in ipfs.
 * [HydrusNetwork] (https://github.com/hydrusnetwork/hydrus) - A booru-style media tagging application with a multitude of features, recently added basic ipfs support.
@@ -87,11 +87,11 @@ These are narrowly-scoped, little JS "apps" deployed through IPFS.
 ## Articles
 
 * 2016-09-12: [IPFS: The Internet Democratised](https://medium.com/@tonywillenberg/web-3-0-a-truly-democratised-internet-f4b06cb4077b) (medium.com)
-* 2016-05-20: [Changelog Podcast](https://changelog.com/204) (changelog.com)
+* 2016-05-20: [Changelog Podcast](https://changelog.com/204/) (changelog.com)
 * 2015-09-10: [First Steps Toward Implementing Distributed Permanent Web With IPFS](https://hacked.com/first-steps-toward-implementing-distributed-permanent-web-ipfs/) (Hacked.com)
 * 2015-09-13: [Introduction to IPFS ](http://whatdoesthequantsay.com/2015/09/13/ipfs-introduction-by-example/) (whatdoesthequantsay.com)
 * 2015-09-18: [The InterPlanetary File System Wants to Create a Permanent Web](http://motherboard.vice.com/read/the-interplanetary-file-system-wants-to-create-a-permanent-web) (Vice // Motherboard)
-* 2015-11-01: [Eris + IPFS](https://db.erisindustries.com/distributed%20business/2015/11/01/eris-and-ipfs/) (erisindustries.com)
+* 2015-11-01: [Eris + IPFS](http://db.erisindustries.com/distributed%20business/2015/11/01/eris-and-ipfs/) (erisindustries.com)
 
 ### Articles independently hosted on IPFS
 * 2015-09-08: [HTTP is obsolete. It's time for the distributed, permanent web](https://ipfs.io/ipfs/QmNhFJjGcMPqpuYfxL62VVB9528NXqDNMFXiqN5bgFYiZ1/its-time-for-the-permanent-web.html)
@@ -111,4 +111,4 @@ Please add (or remove) stuff from this list if you see anything awesome! [Open a
 
 ## License
 
-[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](http://creativecommons.org/publicdomain/zero/1.0/)
+[![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://creativecommons.org/publicdomain/zero/1.0/ | https://creativecommons.org/publicdomain/zero/1.0/ 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://boards.tech/ | https://ipfs.io/ipns/boards.ydns.eu 
https://changelog.com/204 | https://changelog.com/204/ 
https://db.erisindustries.com/distributed%20business/2015/11/01/eris-and-ipfs/ | http://db.erisindustries.com/distributed%20business/2015/11/01/eris-and-ipfs/ 
