### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ These are narrowly-scoped, little JS "apps" deployed through IPFS.
 * [pinbot](https://github.com/whyrusleeping/pinbot) - Pin content via IRC
 * [ipfs-mount](https://github.com/richardschneider/net-ipfs-mount) - Mount IPFS as a mapped drive on Windows
 * [ipfs-add-from-url](https://github.com/maxlath/ipfs-add-from-url) - Add a file to IPFS from a URL instead of a file path
+* [Personal Hash Tracker(PHT)](https://github.com/TroyWilson1/pht) - Store and search IPFS Hash addresses with descriptions 
 
 ## Videos
 


### PR DESCRIPTION
Personal Hash Tracker (PHT) Just a small app that stores IPFS Hashes with a description that you can search. Everything is stored in a JSON file.