### PR TITLE
🎉 Adds Siderus Orion 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ place to ask about it might be in [ipfs/apps](https://github.com/ipfs/apps) or
 * [Alexandria](http://www.alexandria.io/learn/#integrated-technologies) - Decentralized content publishing / monetization platform.
 * [Arbore](http://arbo.re) - A friend-to-friend file-sharing app build on top of IPFS.
 * [beets](https://github.com/beetbox/beets) - Beets has a plugin which allows for easy sharing of music libraries using IPFS
-* [Blokaly](https://www.blokaly.com) - A badge issuing, sharing and display platform based on IPFS.
+* [Blokaly](https://github.com/blokaly) - A badge issuing, sharing and display platform based on IPFS.
 * [Boards](https://ipfs.io/ipns/boards.ydns.eu) - Distributed social platform that runs in the browser. [GitHub](https://github.com/fazo96/ipfs-boards)
 * [Cohort](https://github.com/zignig/cohort) - A golang app to preset a threejs interface and get all of its assets out of IPFS.
 * [Computes](https://computes.io) - Computes.io is a distributed supercomputer powered by IPFS.
 * [dapple](https://github.com/nexusdev/dapple) - Dapple is a Solidity developer multitool designed to manage the growing complexity of interconnected smart contract systems.
-* [digx](https://www.dgx.io/) - Digix is an asset-tokenisation platform built on Ethereum and IPFS.
+* [digx](https://digix.global) - Digix is an asset-tokenisation platform built on Ethereum and IPFS.
 * [dtube](https://d.tube) - Distributed video sharing with steem.it intergrations, using ipfs for backend storage.
 * [Ethlance](http://ethlance.com) - First completely decentralised job market platform built on Ethereum and IPFS. [Github](https://github.com/madvas/ethlance)
 * [git-ipfs-rehost](https://github.com/whyrusleeping/git-ipfs-rehost) - A script to rehost your git repos in ipfs.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ These are narrowly-scoped, little JS "apps" deployed through IPFS.
 * [ipget](https://github.com/ipfs/ipget) - :satellite: wget for IPFS: retrieve files over IPFS and save them locally.
 * [IPRedirect](https://github.com/JayBrown/IPRedirect) - Browser userscript for redirecting IPFS/IPNS addresses to your local gateway. This should work on any browser that hasn’t had an extension written for it yet and has support for userscripts.
 * [ipscend](https://github.com/diasdavid/ipscend) - Tool for hosting web apps and static websites in IPFS
+* [Orion](https://github.com/Siderus/Orion) - KISS, Easy to setup and use IPFS node for macOS, Windows and Linux.
 * [pinbot](https://github.com/whyrusleeping/pinbot) - Pin content via IRC
 * [ipfs-mount](https://github.com/richardschneider/net-ipfs-mount) - Mount IPFS as a mapped drive on Windows
 * [ipfs-add-from-url](https://github.com/maxlath/ipfs-add-from-url) - Add a file to IPFS from a URL instead of a file path


### PR DESCRIPTION
🎉 Adds Siderus Orion 🎉

Our goal is to develop an easy to use and to set up to have a full IPFS node running in background. It is designed around users that are not familiar with IPFS, so that it won't require the use command line but Orion allows the access to the network. Current state: uses Electron and `go-ipfs` with drag-and-drop-like features (aka make it easy-peasy), as well as _pre-caching_ on various gateways, displays not just hashes but also the file names if available and explore IPFS objects with more details (as a File/Property explorer). More feature will come soon :)

Feedback and help is more than welcome 👍 