### PR TITLE
add app: Pathephone

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ place to ask about it might be in [ipfs/apps](https://github.com/ipfs/apps) or
 * [markup.rocks](https://github.com/davidar/markup.rocks) - Pandoc-based markup editor/previewer/converter, ported to IPFS. [Example](https://ipfs.io/ipfs/QmWPgJnUGLB1LPh9KMG9LEN4LVu5e17TwkEtcmTWdNn9V6/#/ipfs/QmfQ75DjAxYzxMP2hdm6o4wFwZS5t7uorEZ2pX9AKXEg2u)
 * [Orbit](https://github.com/haadcode/orbit) - Distributed, peer-to-peer chat application on IPFS.
 * [Partyshare](https://partysha.re) - A simple file sharing app.
+* [Pathephone](https://pathephone.github.io) - Distributed music streaming app.
 * [Filemap](https://filemap.xyz/) - Upload files to a geographic point and never memorize a link again.
 * [FileNation](https://filenation.io/) - The simplest way to send your files around the world using IPFS.
 * [Playback](https://mafintosh.github.io/playback/) - IPFS playback support. This allows casting a video in IPFS to a Chromecast.


### PR DESCRIPTION
Pathephone uses IPFS to share music as well as discover and stream music shared by others.