### PR TITLE
feat: improved search

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -43,11 +43,15 @@ if (search) {
   const input = search.querySelector('input')
 
   input.addEventListener('keyup', () => {
-    const search = input.value
+    let search = input.value
 
     if (search === '') {
       cards.forEach((c) => c.classList.remove('dn'))
       return
+    }
+
+    if (!search.endsWith('*')) {
+      search = `${search} ${search}*`
     }
 
     try {


### PR DESCRIPTION
So I just improved the search a little bit. Now, if you type, let's say, `mark`, it will show everything that starts with "mark" and not only the results that match exactly "mark". 

I didn't do the same for backwards search (like searching for `down` and finding results ending in `down`) because it makes the search slower. Source:

> Leading wildcards, as in the above example, should be used sparingly. They can have a negative impact on the performance of a search, especially in large indexes.
> https://lunrjs.com/guides/searching.html#wildcards

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>