### PR TITLE
add ipfs-dropzone library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@
 
 > Useful resources for using [IPFS](https://ipfs.io) and building things on top of it
 
-_This list is for projects, tools, or pretty much any things related to IPFS that are totally_ **awesome**_. This is for products which are already awesome - if you have plans for cool stuff to do with IPFS, you should build it, and then
-link it here. If you have an idea for an awesome thing to do with IPFS, a good place to ask about it might be in [ipfs/apps](https://github.com/ipfs/apps) or [ipfs/notes](https://github.com/ipfs/notes)._
+_This list is for projects, tools, or pretty much any things related to IPFS that
+are totally_ **awesome**_. This is for products which are already awesome - if
+you have plans for cool stuff to do with IPFS, you should build it, and then
+link it here. If you have an idea for an awesome thing to do with IPFS, a good
+place to ask about it might be in [ipfs/apps](https://github.com/ipfs/apps) or
+[ipfs/notes](https://github.com/ipfs/notes)._
 
 ## Table of Contents
 
-- [Contribute](#contribute-to-this-list)
 - [Apps](#apps)
 - [Articles](#articles)
 - [Tools](#tools)
 - [Videos](#videos)
 - [Discussions](#discussions)
-- [Want to hack on IPFS?](#want-to-hack-on-ipfs)
+- [Contribute](#contribute)
+  - [Want to hack on IPFS?](#want-to-hack-on-ipfs)
 - [License](#license)
-
-## Contribute to this list!
-
-Everyone is welcome to submit their new awesome-ipfs item. Check the [CONTRIBUTING.md guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md) to learn how to do so.
 
 ## Apps
 
@@ -106,6 +106,7 @@ Everyone is welcome to submit their new awesome-ipfs item. Check the [CONTRIBUTI
 - [ipfs-chrome-extension](https://github.com/dylanPowers/ipfs-chrome-extension) - Chrome extension to redirect ipfs.io traffic to local gateway
 - [ipfs-chrome-station](https://github.com/fbaiodias/ipfs-chrome-station) - Chrome extension to redirect ipfs.io traffic to local gateway
 - [ipfs-companion](https://github.com/ipfs/ipfs-companion) - Browser extension that simplifies access to IPFS resources.
+- [ipfs-dropzone](https://github.com/fiatjaf/ipfs-dropzone) - Dropzone.js fork that publishes files instead of uploading to an URL.
 - [ipfs-gui](https://github.com/marcin212/ipfs-gui) - Windows UI integration and IPFS installer
 - [ipfs-gui](https://github.com/marcin212/ipfs-gui) - Windows UI integration and IPFS installer
 - [ipfs-linux-service](https://github.com/dylanPowers/ipfs-linux-service) - IPFS Linux Init Daemon
@@ -132,7 +133,11 @@ Everyone is welcome to submit their new awesome-ipfs item. Check the [CONTRIBUTI
 
 * [CRDTs discussion](https://github.com/ipfs/notes/issues/23)
 
-## Want to hack on IPFS?
+## Contribute
+
+Please add (or remove) stuff from this list if you see anything awesome! [Open an issue](https://github.com/ipfs/awesome-ipfs/issues) or a PR.
+
+### Want to hack on IPFS?
 
 [![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
 

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -25,6 +25,9 @@ content:
   source: https://github.com/ipfs/ipfs-companion
   picture: /images/companion.png
   description: Browser extension that simplifies access to IPFS resources.
+- title: ipfs-dropzone
+  source: https://github.com/fiatjaf/ipfs-dropzone
+  description: Dropzone.js fork that publishes files instead of uploading to an URL.
 - title: ipfs-gui
   source: https://github.com/marcin212/ipfs-gui
   description: Windows UI integration and IPFS installer


### PR DESCRIPTION
https://github.com/fiatjaf/ipfs-dropzone is a fork of the multifamous Dropzone.js library for uploading files to arbitrary URLs. This one instead uses js-ipfs to publish the file to IPFS as it is dropped. It is a fork of the normal Dropzone.js and its API is basically the same.

It currently powers https://filemap.xyz/ and who knows what else (probably nothing else that is in production?).