### PR TITLE
Add npm-ipfsify tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Everyone is welcome to submit their new awesome-ipfs item. In order to add an el
 - [IPLD Explorer](https://explore.ipld.io) - Explore the Merkle Forest from the comfort of your browser [Source](https://github.com/ipfs-shipyard/ipld-explorer)
 - [IPRedirect](https://github.com/JayBrown/IPRedirect) - Browser userscript for redirecting IPFS/IPNS addresses to your local gateway. This should work on any browser that hasn't had an extension written for it yet and has support for userscripts.
 - [ipscend](https://github.com/diasdavid/ipscend) - Tool for hosting web apps and static websites in IPFS
+- [npm-ipfsify](https://www.npmjs.com/package/npm-ipfsify) - Converts NPM packages so they can be loaded directly out of IPFS (no node_modules folder). [Source](https://github.com/zachdeibert/npm-ipfsify)
 - [pinbot](https://github.com/whyrusleeping/pinbot) - Pin content via IRC
 - [Siderus Orion](https://orion.siderus.io) - Easy to use IPFS desktop client for macOS, Windows and Linux [Source](https://github.com/Siderus/Orion)
 

--- a/data/tools.yaml
+++ b/data/tools.yaml
@@ -94,3 +94,7 @@ content:
   description: >
     Monitor the current block number of the Ethereum blockchain, and set alerts (stored locally using
     PouchDB in your browser) for when certain block heights are passed.
+- title: npm-ipfsify
+  website: https://www.npmjs.com/package/npm-ipfsify
+  source: https://github.com/zachdeibert/npm-ipfsify
+  description: Converts NPM packages so they can be loaded directly out of IPFS (no node_modules folder).


### PR DESCRIPTION
npm-ipfsify converts NPM packages so they can be loaded directly out of IPFS (no node_modules folder).