### PR TITLE
Remove filemap.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Everyone is welcome to submit their new awesome-ipfs item. In order to add an el
 - [dtube](https://d.tube) - Distributed video sharing with steem.it intergrations, using ipfs for backend storage.
 - [enzypt.io](https://enzypt.io/) - A website to buy and sell files through Ethereum and IPFS. [Source](https://github.com/flex-dapps/enzypt)
 - [Ethlance](http://ethlance.com) - First completely decentralised job market platform built on Ethereum and IPFS. [Source](https://github.com/madvas/ethlance)
-- [Filemap](https://filemap.xyz/) - Upload files to a geographic point and never memorize a link again.
 - [FileNation](https://filenation.io/) - The simplest way to send your files around the world using IPFS.
 - [git-ipfs-rehost](https://github.com/whyrusleeping/git-ipfs-rehost) - A script to rehost your git repos in ipfs.
 - [Global Upload](https://globalupload.io/) - File transportation service for IPFS, upload files to the future of distributed web.

--- a/data/apps.yaml
+++ b/data/apps.yaml
@@ -145,10 +145,6 @@ content:
     website: https://partysha.re
     description: >
       A simple file sharing app.
-  - title: Filemap
-    website: https://filemap.xyz/
-    description: >
-      Upload files to a geographic point and never memorize a link again.
   - title: FileNation
     website: https://filenation.io/
     description: >


### PR DESCRIPTION
I removed filemap from the app.yaml and README.md files, as it doesn't use ipfs anymore.

I can't run `npm run build:readme`, so I just updated the README manually. If this doesn't suffice, feel free to make this change yourself ;)