### PR TITLE
Add pugdit to application list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Everyone is welcome to submit their new awesome-ipfs item. In order to add an el
 - [Philes](https://philes.co) - A simple browser-based IPFS notepad app. [Source](https://github.com/chrismatthieu/philes)
 - [Playback](https://mafintosh.github.io/playback/) - IPFS playback support. This allows casting a video in IPFS to a Chromecast.
 - [PubSub Chat Demo](https://ipfs.io/ipfs/QmWZ3u5S7RjFXKfW6dSZhj7CozcvpqJxm48RYMmKkWcmNQ/) - A ~76KB demo chat app that uses window.ipfs, provided by the IPFS Companion web extension [Source](https://github.com/tableflip/ipfs-pubsub-chat-example)
+- [Pugdit](https://github.com/zbyte64/pugdit) - A bulletin board service that discovers and distributes over IPFS
 - [PushToTalk](http://timothy.hobbs.cz/push-to-talk/index.html) - Push to Talk lets you edit audio essays and publish them with IPFS.
 - [qri](https://qri.io) - Dataset creation, collaboration, and discovery on the distributed web. [Source](https://github.com/qri-io/qri)
 - [Temporal](https://github.com/RTradeLtd/Temporal) - Temporal is an easy to use API and platform for integrating IPFS and other distributed/decentralized storage technologies into enterprise applications

--- a/data/apps.yaml
+++ b/data/apps.yaml
@@ -265,6 +265,11 @@ content:
     picture: /images/pubsub-chat-demo.png
     description: >
       A ~76KB demo chat app that uses window.ipfs, provided by the IPFS Companion web extension
+  - title: Pugdit
+    website: https://github.com/zbyte64/pugdit
+    source: https://github.com/zbyte64/pugdit
+    description: >
+      A bulletin board service that discovers and distributes over IPFS
   - title: Peer Map Demo
     website: https://ipfs.io/ipfs/QmRPGCmLKH2dQmNiPRsiuYS9EhhJL1Gmkz5F75gKY1K4Bm/
     source: https://github.com/tableflip/ipfs-peer-map-example


### PR DESCRIPTION
A working example of an application using IPFS for service discovery as described here: https://github.com/ipfs/notes/issues/15

Once other peers are discovered, IPNS is used to locate a manifest of signed posts to be considered for replication. 

I mostly consider this project a technology preview of sorts, it was very educational for myself and hope it could teach others. Built using django & vue, configured to run using docker-compose.