### PR TITLE
add entry for xfce-screenshooter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Everyone is welcome to submit their new awesome-ipfs item. In order to add an el
 - [ToDo List Demo](https://ipfs.io/ipfs/QmfFaH6dGibQ5JwEdsujeHBzsmHUsFRB5kU9P8nzPyzMv2/) - A ToDo List demo app that uses windows.ipfs. [Source](https://github.com/ipfs-shipyard/demo-ipfs-todo)
 - [ujo](http://ujomusic.com/) - A blockchain marketplace for musicians.
 - [uport](https://uport.me/#home) - Uport is a mobile, self-sovereign identity and key management system, built on the Ethereum blockchain.
+- [xfce-screenshooter-ipfs-support](https://github.com/amar-laksh/xfce-screenshooter-ipfs-support) - A fork of xfce-screenshooter with glorious image uploading support through Globalupload.io!
 
 ## Articles
 

--- a/data/apps.yaml
+++ b/data/apps.yaml
@@ -291,3 +291,7 @@ content:
       Run your IPFS node on your machine without having to bother with command line tools.
       Manage your node, add your files, easily change the settings... everything from
       just one interface.
+  - title: xfce-screenshooter-ipfs-support
+    source: https://github.com/amar-laksh/xfce-screenshooter-ipfs-support
+    description: >
+        A fork of xfce-screenshooter with glorious image uploading support through Globalupload.io!


### PR DESCRIPTION
This adds a fork of xfce-screenshooter screenshot utility for the XFCE DE with IPFS image uploading support through the globalupload.io API.