### PR TITLE
change IPFSStore  description bitcoin -> steem

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Everyone is welcome to submit their new awesome-ipfs item. In order to add an el
 - [ipfs.ink](https://ipfs.ink) - Publish and render markdown essays to and from ipfs. [Source](https://github.com/kpcyrd/ipfs.ink)
 - [ipfs.pics](https://github.com/ipfspics/ipfspics-server) - Upload and share pics.
 - [IPFSBin](https://github.com/victorbjelkholm/ipfsbin) - Pastebin clone build.
-- [IPFSStore](https://ipfsstore.it) - Pinning paid with Bitcoin
+- [IPFSStore](https://ipfsstore.it) - Pinning paid with Steem
 - [killcord](https://killcord.io/) - A censorship resistant deadman's switch [Source](https://github.com/nomasters/killcord)
 - [markup.rocks](https://ipfs.io/ipfs/QmWPgJnUGLB1LPh9KMG9LEN4LVu5e17TwkEtcmTWdNn9V6/#/ipfs/QmfQ75DjAxYzxMP2hdm6o4wFwZS5t7uorEZ2pX9AKXEg2u) - Pandoc-based markup editor/previewer/converter, ported to IPFS. [Source](https://github.com/davidar/markup.rocks)
 - [NodeFort.io](https://www.nodefort.io) - Web-based IPFS node hosting service.

--- a/data/apps.yaml
+++ b/data/apps.yaml
@@ -129,7 +129,7 @@ content:
   - title: IPFSStore
     website: https://ipfsstore.it
     description: >
-      Pinning paid with Bitcoin
+      Pinning paid with Steem
   - title: markup.rocks
     website: https://ipfs.io/ipfs/QmWPgJnUGLB1LPh9KMG9LEN4LVu5e17TwkEtcmTWdNn9V6/#/ipfs/QmfQ75DjAxYzxMP2hdm6o4wFwZS5t7uorEZ2pX9AKXEg2u
     source: https://github.com/davidar/markup.rocks


### PR DESCRIPTION
It has changed for some reason:

  * https://ipfsstore.it/about.php
  * https://steemit.com/@ipfsstore/transfers