### PR TITLE
feat: wider page and better columns

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -33,6 +33,8 @@ body {
 .Card {
   margin: 0 0 1em 0;
   width: 100%;
+  page-break-inside: avoid;
+  break-inside: avoid;
 }
 
 @media (max-width: 1000px) {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -8,19 +8,6 @@ body {
   overflow-y: scroll;
 }
 
-.grow2 {
-  -moz-osx-font-smoothing: grayscale;
-  backface-visibility: hidden;
-  transform: translateZ(0);
-  transition: transform 0.25s ease-out;
-}
-
-.grow2:active,
-.grow2:hover,
-.grow2:focus {
-  transform: scale(1.05);
-}
-
 .focus-outline:focus {
   outline: 0;
   box-shadow: 0 0 0 .2rem rgba(201, 210, 215, .4);
@@ -36,4 +23,32 @@ body {
 
 .fill-white {
   fill: white;
+}
+
+.CardContainer {
+  column-count: 4;
+  column-gap: 1em;
+}
+
+.Card {
+  margin: 0 0 1em 0;
+  width: 100%;
+}
+
+@media (max-width: 1000px) {
+  .CardContainer {
+    column-count: 3;
+  }
+}
+
+@media (max-width: 800px) {
+  .CardContainer {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 600px) {
+  .CardContainer {
+    column-count: 1;
+  }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -28,10 +28,10 @@ function update (display) {
   cards.forEach((c) => {
     if (display.indexOf(c.dataset.ref) >= 0) {
       c.classList.remove('dn')
-      c.classList.add('flex')
+      c.classList.add('dib')
     } else {
       c.classList.add('dn')
-      c.classList.remove('flex')
+      c.classList.remove('dib')
     }
   })
 }

--- a/src/layouts/_default/baseof.html
+++ b/src/layouts/_default/baseof.html
@@ -5,8 +5,8 @@
   {{ partial "analytics" . }}
 </head>
 <body>
-  <div class="charcoal sans-serif w-90 mw8 center">
-    <nav class="mh2 montserrat mv4 fw6 flex-wrap ttu tracked sans-serif flex flex-between">
+  <div class="charcoal sans-serif w-90 mw9 center">
+    <nav class="montserrat mv4 fw6 flex-wrap ttu tracked sans-serif flex flex-between">
       <a href="{{ .Site.BaseURL }}/" class="w-100 w-auto-l flex items-center pv3 pv0-l mr3 flex-grow-1 flex items-center justify-center justify-start-l no-underline" >
         <img alt="IPFS" src="{{ .Site.BaseURL }}/images/logo.png" class="w3 h3 mr3">
         <h1 class="f3 white">Awesome IPFS</h1>
@@ -23,7 +23,7 @@
 
     {{ template "main" . }}
 
-    <footer class="mv4 mh2 montserrat ttu tc snow tracked b">
+    <footer class="mv4 montserrat ttu tc snow tracked b">
       <a target="_blank" href="https://github.com/ipfs/awesome-ipfs" class="snow no-underline">GitHub</a> | 
       <a target="_blank" href="https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md" class="snow no-underline"> Suggest a new item</a> |
       <a target="_blank" href="https://discuss.ipfs.io/c/ecosystem" class="snow no-underline">Discuss</a>

--- a/src/layouts/partials/list.html
+++ b/src/layouts/partials/list.html
@@ -13,16 +13,16 @@
 </a>
 {{ end }}
 
-<div class="ma2 dn" id="search">
+<div class="mv2 dn" id="search">
   <input
     placeholder="Find your awesome app..."
     class="input-reset outline-0 bn pa3 mb2 db w-100 center focus-outline dn"
     type="text" />
 </div>
 
-<main class="CardContainer mv4 flex flex-wrap justify-between" >
+<main class="CardContainer mv4" >
   {{ range (sort .Params.content "index") -}}
-  <article data-ref="{{ .index }}" class="Card flex flex-column bg-white shadow-4 grow2 br1 dark-gray b--black-10 flex-grow-1 ma2">
+  <article data-ref="{{ .index }}" class="Card dib bg-white shadow-4 br1 dark-gray b--black-10 ma2">
     <div class="bg-navy ttu fw6 tracked montserrat bg-{{ .color }}-muted br1 br--top white pv1 ph2 ph3-ns f7 b w-100">
       {{ humanize .category }}
     </div>


### PR DESCRIPTION
First of all, this removes the grow effect when hovering around items (fixes #241). The effect wasn't really helping with anything in the interface by causing blurriness. Perhaps in the feature we can find a better way to give focus to the current 'hovered' item.

![image](https://user-images.githubusercontent.com/5447088/61176082-8b385f80-a5b2-11e9-8dd1-847ab2aeb6b8.png)

Secondly, this makes the page wider and stops using flex boxes for the columns and uses CSS columns instead. With this, the items don't need to be vertically aligned, so they don't need to take up the same space. That way, this won't happen anymore:

![image](https://user-images.githubusercontent.com/5447088/61176091-bae76780-a5b2-11e9-842a-93bc28c04c84.png)

Of course this has its own drawbacks: the bottom items aren't aligned and perfectly beautiful. But I believe this is a much better looking solution than having big empty blocks.

![image](https://user-images.githubusercontent.com/5447088/61176098-cc307400-a5b2-11e9-9b48-4ecce9b5292c.png)

The max columns we have is four, and they adapt to 3, 2 and 1 at certain breaking points.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>
