### PR TITLE
Readd WistfulBooks/LibriVox to datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Sniffs the DHT gossip and indexes file and directory hashes. Metadata and search
 - [Presidental Daily Briefs](https://ipfs.io/ipfs/Qme6epvZDj3vzHcFKdF1nZhbixjw8Bn4imGcKnbUyBJL89)  [Source](https://github.com/ipfs/archives/issues/23)
 - [Project Apollo Archives](https://ipfs.io/ipfs/QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D)  [Source](https://github.com/ipfs/archives/issues/143)
 - [textfiles.com](https://ipfs.io/ipfs/QmNoscE3kNc83dM5rZNUC5UDXChiTdDcgf16RVtFCRWYuU)  [Source](https://github.com/ipfs/archives/issues/155)
+- [WistfulBooks: LibriVox Audiobook Archive](https://wistfulbooks.com) - Free public domain audiobooks from LibriVox.org packaged into a single page that lets you listen to audiobooks in your browser. [Source](https://github.com/smwa/wistfulbooks)
 - [World Wide Web History Project](https://ipfs.io/ipfs/QmRTSA1UFHSx3z7taNRwUVM8AjB2EQwKvyZu3BfJg9QRtZ)  [Source](https://github.com/ipfs/archives/issues/159)
 - [xkcd](https://ipfs.io/ipns/xkcd.hacdias.com)  [Source](https://github.com/ipfs/archives/issues/21)
 - [yarchive.net](https://ipfs.io/ipfs/QmdA5WkDNALetBn4iFeSepHjdLGJdxPBwZyY47ir1bZGAK)  [Source](https://github.com/ipfs/archives/issues/76)

--- a/data/datasets.yml
+++ b/data/datasets.yml
@@ -107,3 +107,9 @@ content:
     source: https://github.com/ipfs/archives/issues/172
     description:
     size: 30GB
+  - title: Librivox Audio Books
+    hash: /ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
+    website: https://ipfs.io/ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
+    source: https://github.com/ipfs/archives/pull/199/
+    description: Archived content of Librivox including the script that generated it
+    size: 2.0 TiB

--- a/data/datasets.yml
+++ b/data/datasets.yml
@@ -107,9 +107,9 @@ content:
     source: https://github.com/ipfs/archives/issues/172
     description:
     size: 30GB
-  - title: LibriVox Audiobooks
+  - title:  WistfulBooks: LibriVox Audiobook Archive
     hash: /ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
-    website: https://ipfs.io/ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
-    source: https://github.com/ipfs/archives/pull/199/
-    description: Free public domain audiobooks. Archived content of LibriVox including the script that generated it.
+    website: https://wistfulbooks.com
+    source: https://github.com/smwa/wistfulbooks
+    description: Free public domain audiobooks from LibriVox.org packaged into a single page that lets you listen to audiobooks in your browser.
     size: 2.0 TiB

--- a/data/datasets.yml
+++ b/data/datasets.yml
@@ -107,7 +107,7 @@ content:
     source: https://github.com/ipfs/archives/issues/172
     description:
     size: 30GB
-  - title:  WistfulBooks: LibriVox Audiobook Archive
+  - title:  'WistfulBooks: LibriVox Audiobook Archive'
     hash: /ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
     website: https://wistfulbooks.com
     source: https://github.com/smwa/wistfulbooks

--- a/data/datasets.yml
+++ b/data/datasets.yml
@@ -107,9 +107,9 @@ content:
     source: https://github.com/ipfs/archives/issues/172
     description:
     size: 30GB
-  - title: Librivox Audio Books
+  - title: LibriVox Audiobooks
     hash: /ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
     website: https://ipfs.io/ipfs/QmXyNMhV8bQFp6wzoVpkz3NqDi7Fj72Deg7KphAuew3RYU
     source: https://github.com/ipfs/archives/pull/199/
-    description: Archived content of Librivox including the script that generated it
+    description: Free public domain audiobooks. Archived content of LibriVox including the script that generated it.
     size: 2.0 TiB


### PR DESCRIPTION
It was added https://github.com/ipfs/archives/pull/199/files but somehow to lost in the migration from a static page to a dynamically generated page.

## What kind of change is it?

- [x] Addition
- [ ] Removal
- [ ] Edit
- [ ] Other

<!-- If your change is not listed above, please remove the checklist bellow. -->

### Checklist

- [x] I edited the `/data` directory instead of the [README.md](https://github.com/ipfs/awesome-ipfs/blob/master/README.md).
- [x] This PR includes only one addition/removal/edit.
- [x] I ran the `make build` command following my edits to the `/data` directory.
- [x] I have followed the [CONTRIBUTING.md guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md).

## Details

Provide details of your changes here.
