### PR TITLE
fix: remove broken link for DtinyUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Readme and the website are automatically generated. In order to add an element t
 - [Diffuse](https://diffuse.sh) - Play music from your IPFS node, or any other cloud/distributed storage service you use.
 - [digx](https://www.dgx.io/) - Digix is an asset-tokenisation platform built on Ethereum and IPFS.
 - [Discussify](https://github.com/ipfs-shipyard/discussify-browser-extension) - Discussify provides a real-time, peer to peer, and permanent discussion platform for anyone to join and participate.
-- [DtinyUrl](http://t.bdaily.club) - Dcentralized URL shortening service based on IPFS. [Source](https://github.com/facert/dtinyurl)
+- [DtinyUrl](https://github.com/facert/dtinyurl) - Decentralized URL shortening service based on IPFS.
 - [dtube](https://d.tube) - Distributed video sharing with steem.it intergrations, using ipfs for backend storage.
 - [enzypt.io](https://enzypt.io/) - A website to buy and sell files through Ethereum and IPFS. [Source](https://github.com/flex-dapps/enzypt)
 - [Ethlance](http://ethlance.com) - First completely decentralised job market platform built on Ethereum and IPFS. [Source](https://github.com/madvas/ethlance)

--- a/data/apps.yaml
+++ b/data/apps.yaml
@@ -350,10 +350,9 @@ content:
     description: >
       Decentralized two factor authentication app built on Textile & IPFS.
   - title: DtinyUrl
-    website: http://t.bdaily.club
     source: https://github.com/facert/dtinyurl
     description: >
-      Dcentralized URL shortening service based on IPFS.
+      Decentralized URL shortening service based on IPFS.
   - title: Wistful Books
     website: https://wistfulbooks.com/
     source: https://github.com/smwa/wistfulbooks


### PR DESCRIPTION
Removed https://t.bdaily.club as it returns 502 (using github repo URL instead).


cc https://github.com/ipfs/awesome-ipfs/pull/228 
@facert feel free re-add website URL in separate PR if you plan to fix it.