### PR TITLE
add collab clusters as a fixed entry to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ _This list is for projects, tools, or pretty much any things related to IPFS tha
 ## Table of Contents
 
 - [Contribute](#contribute-to-this-list)
+- [Collab-Cluster](#collab-cluster)
 - [Apps](#apps)
 - [Articles](#articles)
 - [Datasets](#datasets)
@@ -27,6 +28,9 @@ Everyone is welcome to submit their new awesome-ipfs item, but it will be accept
 
 Readme and the website are automatically generated. In order to add an element to this list, you need to modify the files in `/data` and then run  `make build` before publishing your pull request. Read [contributing guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md) to learn how to do so.
 
+## Collab-Cluster
+
+[Collaborative clusters](https://collab.ipfscluster.io/) are public IPFS Clusters that anyone can join to help replicating and re-distributing content on the IPFS network. Instead of datasets cluster content is usually updated.
 
 ## Apps
 

--- a/scripts/readme-template.md
+++ b/scripts/readme-template.md
@@ -11,6 +11,7 @@ _This list is for projects, tools, or pretty much any things related to IPFS tha
 ## Table of Contents
 
 - [Contribute](#contribute-to-this-list)
+- [Collab-Cluster](#collab-cluster)
 #PLACEHOLDER_TOC#
 - [Discussions](#discussions)
 - [Want to hack on IPFS?](#want-to-hack-on-ipfs)
@@ -22,6 +23,9 @@ Everyone is welcome to submit their new awesome-ipfs item, but it will be accept
 
 Readme and the website are automatically generated. In order to add an element to this list, you need to modify the files in `/data` and then run  `make build` before publishing your pull request. Read [contributing guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md) to learn how to do so.
 
+## Collab-Cluster
+
+[Collaborative clusters](https://collab.ipfscluster.io/) are public IPFS Clusters that anyone can join to help replicating and re-distributing content on the IPFS network. Instead of datasets cluster content is usually updated.
 
 #PLACEHOLDER_CATEGORIES#
 


### PR DESCRIPTION
## What kind of change is it?

- [x] Addition

### Checklist

- [x] I edited the `/data` directory instead of the [README.md](https://github.com/ipfs/awesome-ipfs/blob/master/README.md).
- [x] This PR includes only one addition/removal/edit.
- [x] I ran the `make build` command following my edits to the `/data` directory.
- [x] I reviewed the [content policy](https://github.com/ipfs/awesome-ipfs/blob/master/POLICY.md) to ensure my submission meets the requirements.
- [x] I have followed the [CONTRIBUTING.md guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md).

## Details

The collab clusters are listed on a dedicated webpage, so I only added a static text to the readme which contains a link to the webpage. 

Listing them in two locations doesn't make much sense, I guess.
