### PR TITLE
Fix mid-word line breaks & right-side whitespace

### DIFF
--- a/src/layouts/partials/list.html
+++ b/src/layouts/partials/list.html
@@ -1,5 +1,5 @@
 {{ define "text" }}
-<p class="f6 lh-copy mw5 mt2 mb0 mid-gray" style="word-break: break-all">
+<p class="f6 lh-copy mt2 mb0 mid-gray" style="word-break: break-word">
   {{- markdownify . -}}
 </p>
 {{ end }}
@@ -31,7 +31,7 @@
       <div class="dt w-100 mt1">
         <div class="dtc">
           <a target="_blank" class="no-underline charcoal" href="{{ if .website }}{{ .website }}{{ else if .source }}{{ .source }}{{ else if .demo }}{{ .demo }}{{ end }}">
-            <h1 class="f5 mw5 f4-ns mv0">{{- .title -}}</h1>
+            <h1 class="f5 f4-ns mv0">{{- .title -}}</h1>
           </a>
         </div>
       </div>
@@ -49,13 +49,13 @@
       {{- end -}}
 
       {{- if isset . "hash" -}}
-        <div class="mt2 mw5">
+        <div class="mt2">
           {{ template  "hash" .hash }}
         </div>
       {{- end -}}
 
       {{- if isset . "picture" -}}
-      <div class="mt2 mw5">
+      <div class="mt2">
         <a target="_blank" class="no-underline charcoal" href="{{ if .website }}{{ .website }}{{ else if .source }}{{ .source }}{{ else if .demo }}{{ .demo }}{{ end }}">
           <img class="br2" src="{{ .picture | relURL }}" >
         </a>


### PR DESCRIPTION
## What kind of PR is this?
**Select only one** *to speed up review/approval; i.e., don't lump an addition and a removal into a single PR.*

- [ ] **Adding** something new to awesome-ipfs
- [ ] **Editing** something already listed on awesome-ipfs
- [ ] **Removing** something from awesome-ipfs
- [x] **Something else** *(if so, please explain in the "Additional details" section below)*

<!-- If your change is not listed above, please remove the checklist bellow. -->

## Pre-submit checklist
**Please confirm ALL of the following** before submitting your PR.

- [x] This PR includes only one addition, removal, or edit.
- [x] **(N/A)** I edited the `/data` directory instead of the [README.md](https://github.com/ipfs/awesome-ipfs/blob/master/README.md).
- [x] I reviewed the [content policy](https://github.com/ipfs/awesome-ipfs/blob/master/POLICY.md) and the and the [IPFS Community Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md) to ensure my submission meets the requirements.
- [x] I have followed the [CONTRIBUTING.md guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md).

## Additional details

### Is there anything else we should know about this PR?
<!-- If you've checked "Something else" above, or just want to provide additional info or clarification, please do so here. -->
This PR is to fix formatting/layout issues in how text and images fit on cards on awesome.ipfs.io.

### Before:
![before](https://user-images.githubusercontent.com/17075501/99030435-da393080-2529-11eb-94eb-08a187d543ef.png)

### After:
![after](https://user-images.githubusercontent.com/17075501/99030274-7878c680-2529-11eb-8d96-6ae91d7b0f24.png)

### Details
Line breaking in paragraphs in cards was set to "break-all" and would
break lines in the middle of words, making reading difficult. Changing
to "break-word" tries to break between words or at hyphens, which makes
reading cards much easier.

In addition, the headers and paragraphs in cards had a maximum width set
using the mw5 class tag, which is set as 16rem in ./src/static/app.css.
However, this maximum width only spans around 3/4 of width of the
card, so there was a column of whitespace on the right hand side of the
card. Removing the "class=mw5" constraint from the headers, paragraphs,
images, and hashes in cards allows the bounding boxes for these items to
expand to the right-side margin of the card. The title, text, and image
now fill the card and dynamically adjust width if the overall window
changes width.
