### PR TITLE
fix: broken-links workflow

### DIFF
--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -41,14 +41,14 @@ jobs:
       id: remove-broken-links
       run: |
         node scripts/remove-broken-links.js
+        echo "Changed files:"
         git ls-files -m
-        git diff --name-only | cat
-        num_changed_files=$(git ls-files -m | wc -l | tr -d ' ')
-        echo "num_changed_files='$num_changed_files'"
-        echo "::set-output name=changed_files::$num_changed_files"
+        changed_data_files_count=$(git ls-files -m data | wc -l | tr -d ' ')
+        echo "changed_data_files_count='$changed_data_files_count'"
+        echo "::set-output name=changed_files::$changed_data_files_count"
 
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
-      if: steps.remove-broken-links.outputs.changed_files != '0'
+      if: steps.remove-broken-links.outputs.changed_data_files_count > 0
       with:
         # Optional. Commit message for the created commit.
         # Defaults to "Apply automatic changes"
@@ -77,7 +77,7 @@ jobs:
         create_branch: true
 
     - name: pull-request
-      if: steps.remove-broken-links.outputs.changed_files != '0'
+      if: steps.remove-broken-links.outputs.changed_data_files_count > 0
       uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde
       with:
         source_branch: "remove-broken-links-${{ github.run_id }}"

--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -41,11 +41,12 @@ jobs:
       id: remove-broken-links
       run: |
         node scripts/remove-broken-links.js
-        changed_files=$(git ls-files -m | wc -l | tr -d ' ')
-        echo "::set-output name=changed_files::$changed_files"
+        num_changed_files=$(git ls-files -m | wc -l | tr -d ' ')
+        echo "num_changed_files='$num_changed_files'"
+        echo "::set-output name=changed_files::$num_changed_files"
 
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
-      if: ${{ steps.remove-broken-links.outputs.changed_files != '0' }}
+      if: steps.remove-broken-links.outputs.changed_files != '0'
       with:
         # Optional. Commit message for the created commit.
         # Defaults to "Apply automatic changes"
@@ -74,7 +75,7 @@ jobs:
         create_branch: true
 
     - name: pull-request
-      if: ${{ steps.remove-broken-links.outputs.changed_files != '0' }}
+      if: steps.remove-broken-links.outputs.changed_files != '0'
       uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde
       with:
         source_branch: "remove-broken-links-${{ github.run_id }}"

--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -45,7 +45,7 @@ jobs:
         echo "::set-output name=changed_files::$changed_files"
 
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
-      if: ${{ steps.remove-broken-links.outputs.changed_files != "0" }}
+      if: ${{ steps.remove-broken-links.outputs.changed_files != '0' }}
       with:
         # Optional. Commit message for the created commit.
         # Defaults to "Apply automatic changes"
@@ -74,7 +74,7 @@ jobs:
         create_branch: true
 
     - name: pull-request
-      if: ${{ steps.remove-broken-links.outputs.changed_files != "0" }}
+      if: ${{ steps.remove-broken-links.outputs.changed_files != '0' }}
       uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde
       with:
         source_branch: "remove-broken-links-${{ github.run_id }}"

--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -41,7 +41,7 @@ jobs:
       id: remove-broken-links
       run: |
         node scripts/remove-broken-links.js
-        changed_files=$(git ls-files -m | wc -l)
+        changed_files=$(git ls-files -m | wc -l | tr -d ' ')
         echo "::set-output name=changed_files::$changed_files"
 
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80

--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -41,6 +41,8 @@ jobs:
       id: remove-broken-links
       run: |
         node scripts/remove-broken-links.js
+        git ls-files -m
+        git diff --name-only | cat
         num_changed_files=$(git ls-files -m | wc -l | tr -d ' ')
         echo "num_changed_files='$num_changed_files'"
         echo "::set-output name=changed_files::$num_changed_files"

--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -45,7 +45,7 @@ jobs:
         echo "::set-output name=changed_files::$changed_files"
 
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
-      if: ${{ steps.remove-broken-links.outputs.changed_files > 0 }}
+      if: ${{ steps.remove-broken-links.outputs.changed_files != "0" }}
       with:
         # Optional. Commit message for the created commit.
         # Defaults to "Apply automatic changes"
@@ -74,7 +74,7 @@ jobs:
         create_branch: true
 
     - name: pull-request
-      if: ${{ steps.remove-broken-links.outputs.changed_files > 0 }}
+      if: ${{ steps.remove-broken-links.outputs.changed_files != "0" }}
       uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde
       with:
         source_branch: "remove-broken-links-${{ github.run_id }}"

--- a/.github/workflows/broken_link_cron.yml
+++ b/.github/workflows/broken_link_cron.yml
@@ -38,10 +38,14 @@ jobs:
         awesome_bot --allow 429 --allow-redirect --allow-dupe --allow-ssl -w ipfs.io README.md || echo
 
     - name: Remove broken links
+      id: remove-broken-links
       run: |
         node scripts/remove-broken-links.js
+        changed_files=$(git ls-files -m | wc -l)
+        echo "::set-output name=changed_files::$changed_files"
 
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
+      if: ${{ steps.remove-broken-links.outputs.changed_files > 0 }}
       with:
         # Optional. Commit message for the created commit.
         # Defaults to "Apply automatic changes"
@@ -70,6 +74,7 @@ jobs:
         create_branch: true
 
     - name: pull-request
+      if: ${{ steps.remove-broken-links.outputs.changed_files > 0 }}
       uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde
       with:
         source_branch: "remove-broken-links-${{ github.run_id }}"

--- a/scripts/remove-broken-links.js
+++ b/scripts/remove-broken-links.js
@@ -25,4 +25,6 @@ if (markdownTable.error) {
       await fs.writeFile(filePath, fileContents, 'utf8')
     }
   })()
+} else {
+  console.log('No errors reported by awesome_bot.')
 }


### PR DESCRIPTION
Fix issues where job would run and still attempt to commit and create PR if
no errors were reported.

See https://github.com/ipfs/awesome-ipfs/actions/runs/3064434657/jobs/4947529925

Also see manual runs on the branch this PR is for: https://github.com/ipfs/awesome-ipfs/actions/workflows/broken_link_cron.yml
