### PR TITLE
Add ShieldOS Drive to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Check out the list of [IPFS implementations](https://docs.ipfs.tech/concepts/ipf
 - [Plebbit](https://github.com/plebbit) - Plebbit is a serverless, adminless, decentralised and infinitely scalable Social Media platform that is peer-to-peer and open-source.It's built on top of IPFS, Gossipsub and Blockchain namesystems (ENS, SNS).
 - [PushToTalk](http://timothy.hobbs.cz/push-to-talk/index.html) - Push to Talk lets you edit audio essays and publish them with IPFS.
 - [Quiet](https://tryquiet.org/) - Privacy focused, end-to-end encrypted chat app that runs a private IPFS network over Tor connections. Desktop and mobile iOS and Android apps available.
+- [ShieldOS Drive](https://www.shieldos.xyz) - Encrypted, privacy-first file manager using IPFS as decentralized storage inside the ShieldOS operating system. Source: https://github.com/Shield-OS-dev/shieldos-core
 - [TeaTime](https://github.com/bjesus/teatime) - A fully static distributed library system powered by IPFS, SQLite and GitHub.
 
 ## Browsers


### PR DESCRIPTION
This PR adds **ShieldOS Drive** to the list of apps.

ShieldOS Drive uses IPFS as the decentralized storage layer for encrypted file uploads inside the ShieldOS privacy operating system.

- Website: https://www.shieldos.xyz
- Source: https://github.com/Shield-OS-dev/shieldos-core
