### PR TITLE
Add Upload to Web3 Apify actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A list of web browsers with IPFS integrations
 - [SimpleAsWater Bot](https://github.com/simpleaswater/twitter-pinbot) - A twitter bot that adds, pins, unpins your tweets to public IPFS network using IPFS Cluster.
 - [solid-ipfs](https://github.com/Eximua/solid-ipfs) - Using Solid to store IPFS Hash privately or publicly.
 - [Tellit](https://gitlab.com/terceranexus6/tellit) - Encrypt files before uploading them using a keypair or a passphrase.
+- [Upload to Web3](https://github.com/onescales/Upload-to-Web3) - Apify app for automated file uploads to decentralized storage via IPFS nodes and Pinata pinning service.
 - [VIPFS](https://github.com/Ideea-inc/vipfs) - Publish your Vue apps easily to IPFS.
 - [wbipfs](https://github.com/wabarc/wbipfs) - A command-line tool and Go package interface for wayback webpage to IPFS.
 - [youtube2ipfs](https://github.com/dokterbob/youtube2ipfs) - Download videos from YouTube (and similar video platforms) and add them to IPFS.


### PR DESCRIPTION
Adds Upload to Web3, an open-source Apify actor for automated file uploads to IPFS and Pinata.

**Project Links:**
- GitHub: https://github.com/onescales/Upload-to-Web3
- Apify Store: https://apify.com/onescales/upload-to-web3
- Video Walkthrough: https://www.youtube.com/watch?v=P0e-eD_dUTY

**Why it should be included:**
- Open source (MIT license)
- Uses IPFS directly and Pinata's pinning service
- Enables no-code automation for decentralized storage workflows
- Immediately usable on the Apify platform
- Makes IPFS accessible to non-developers and businesses

**Meets content policy:**
✅ Uses IPFS
✅ Open source with linked repository
✅ Immediately usable (free tier available)
✅ Clear documentation and license