### PR TITLE
Add Edky to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A list of web browsers with IPFS integrations
 - [create-ipfs-app](https://github.com/alexbakers/create-ipfs-app) - Set up a decentralized web3 app by running one command.
 - [dScan](https://github.com/p2plabsxyz/dscan) - A browser extension that uploads the content to Web3.Storage and generates QR codes for CIDs.
 - [dump-ipfs](https://github.com/quasarch/dump-ipfs) - A decentralized encrypted backup agent for popular databases supported by IPFS and Filecoin.
+- [Edky](https://github.com/artob/edky) - A command-line utility to convert Ed25519 public keys between various encoding formats (IPFS, libp2p, iroh, OpenSSH, etc).
 - [gatsby-plugin-ipfs](https://github.com/moxystudio/gatsby-plugin-ipfs) - Adds support for deploying Gatsby websites to IPFS by ensuring that assets are relative.
 - [git-ipfs-rehost](https://github.com/whyrusleeping/git-ipfs-rehost) - A script to rehost your git repos in ipfs.
 - [git-remote-ipfs](https://github.com/cryptix/git-remote-ipfs) - push/pull repositories from/to IPFS.


### PR DESCRIPTION
**[Edky] converts Ed25519 public keys between various encoding formats, including IPFS's (aka libp2p, Multibase).**

```shellsession
$ cargo binstall -y edky

$ edky convert -f ipfs -t hex z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw
d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a

$ edky convert -f ipfs -t base64url z6MktwupdmLXVVqTzCw4i46r4uGyosGXRnR3XjN4Zq7oMMsw
11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo
```

<img width="100%" alt="Showcase of edky convert" src="https://github.com/artob/edky/raw/master/rust/etc/asciinema/convert.gif"/>

[Edky]: https://github.com/artob/edky

## Pre-submit checklist

- [x] This PR includes only one addition, removal, or edit.
- [x] I have followed the [Contribution Guidelines](https://github.com/ipfs/awesome-ipfs/blob/master/CONTRIBUTING.md).
- [x] I reviewed the [IPFS Community Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md) to ensure my submission meets the requirements.
