### PR TITLE
docs: add ipfs-pay-to-pin-client to Pinning services

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ A list of web browsers with IPFS integrations
 ## Pinning services
 - [4EVERLAND](https://www.4everland.org/) - 4EVERLAND is a pinning service that provides IPFS infrastructure and tooling making it easier and faster to host frontends, store data/NFT/file and fetch data with IPFS.
 - [Filebase](https://filebase.com/) - Pinning data to IPFS can be hard. Filebase removes that complexity.
+- [ipfs-pay-to-pin-client](https://github.com/IcanBENCHurCAT/ipfs-pay-to-pin) - Pay-to-pin IPFS storage via x402 microUSDC micropayments. Multi-chain (Base L2, Solana, Algorand, Ethereum L1), 365-day retention, 1-line SDK for AI agents and applications.
 - [lighthouse.storage](https://lighthouse.storage/) - A decentralized IPFS pinning service with privacy and encryption capabilities
 - [NFT.Storage](https://nft.storage/) - Free decentralized storage and bandwidth for NFTs on IPFS & Filecoin.
 - [Pinata](https://pinata.cloud) - Build and manage your dapp through Pinata’s REST API and IPFS toolkit.


### PR DESCRIPTION
Add ipfs-pay-to-pin-client to the Pinning services section.\n\n**About**\nPay-to-pin IPFS storage via x402 microUSDC micropayments. Multi-chain (Base L2, Solana, Algorand, Ethereum L1), 365-day retention, 1-line SDK for AI agents and applications.\n\n**Why it fits here**\nAdds a native micropayment layer to IPFS pinning. Pairs well alongside established services like Pinata, Filebase, and NFT.Storage.\n\n**Links**\n- GitHub: https://github.com/IcanBENCHurCAT/ipfs-pay-to-pin\n- PyPI: https://pypi.org/project/ipfs-pay-to-pin-client/\n- NPM: https://www.npmjs.com/package/ipfs-pay-to-pin-client