### PR TITLE
Add VaultKeepR to Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Check out the list of [IPFS implementations](https://docs.ipfs.tech/concepts/ipf
 - [TeaTime](https://github.com/bjesus/teatime) - A fully static distributed library system powered by IPFS, SQLite and GitHub.
 
 - [VaultKeepR](https://github.com/VaultKeepR/vaultkeepr-public) - Zero-knowledge password manager that stores encrypted vaults on IPFS. No email, no account: identity is an on-chain smart account and all sync is done as encrypted content-addressed blobs.
+
 ## Browsers
 A list of web browsers with IPFS integrations
 - [Agregore](https://github.com/AgregoreWeb/agregore-browser) - A minimal web browser for the distributed web. Supports downloading/uploading data from IPFS using the browser's `fetch()` API

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Check out the list of [IPFS implementations](https://docs.ipfs.tech/concepts/ipf
 - [Quiet](https://tryquiet.org/) - Privacy focused, end-to-end encrypted chat app that runs a private IPFS network over Tor connections. Desktop and mobile iOS and Android apps available.
 - [TeaTime](https://github.com/bjesus/teatime) - A fully static distributed library system powered by IPFS, SQLite and GitHub.
 
+- [VaultKeepR](https://github.com/VaultKeepR/vaultkeepr-public) - Zero-knowledge password manager that stores encrypted vaults on IPFS. No email, no account: identity is an on-chain smart account and all sync is done as encrypted content-addressed blobs.
 ## Browsers
 A list of web browsers with IPFS integrations
 - [Agregore](https://github.com/AgregoreWeb/agregore-browser) - A minimal web browser for the distributed web. Supports downloading/uploading data from IPFS using the browser's `fetch()` API


### PR DESCRIPTION
VaultKeepR is a zero-knowledge password manager built on IPFS: the encrypted vault syncs as content-addressed blobs, the user holds the CID, and there is no server-side database of users (identity = on-chain smart account, no email needed). Open source: https://github.com/VaultKeepR/vaultkeepr-public

Fits the Apps section (credential storage on IPFS, like Peergos for files). Added in alphabetical order per the current listing convention